### PR TITLE
Remove duplicate "MIN_PERL_VERSION" in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,7 +30,6 @@ WriteMakefile1(
     'Term::ExtendedColor'       => '0',
     'Term::ExtendedColor::Dzen' => '0',
   },
-  MIN_PERL_VERSION             => 5.0010,
   MAN1PODS                     => { },
   dist                         => { COMPRESS => q{gzip -9f},    SUFFIX => q{gz}, },
   clean                        => { FILES    => q{},                  },


### PR DESCRIPTION
5.0010 looks like be a typo of 5.010, it would actually evaluate to v5.1, so removing that key.